### PR TITLE
Fix calendar day numbering issue with timezone

### DIFF
--- a/ember-power-calendar-moment/src/index.js
+++ b/ember-power-calendar-moment/src/index.js
@@ -135,7 +135,7 @@ export function normalizeMultipleActionValue(val) {
 }
 
 export function normalizeCalendarDay(day) {
-  day.moment = moment(day.date);
+  day.number = moment(day.date).date();
   return day;
 }
 


### PR DESCRIPTION
Fixes https://github.com/cibernox/ember-power-calendar/issues/237

Uses moment's date() to set the correct calendar number based on the timezone.